### PR TITLE
async has been made as keyword in 3.7+; correct the syntax the error on 3.7+

### DIFF
--- a/vibora/blueprints.py
+++ b/vibora/blueprints.py
@@ -169,7 +169,7 @@ class Blueprint:
         :param hook:
         :return:
         """
-        collection = self.async_hooks if hook.async else self.hooks
+        collection = self.async_hooks if hook.is_async else self.hooks
         collection[hook.event_type].append(hook)
 
     def add_route(self, route: Route):

--- a/vibora/hooks.py
+++ b/vibora/hooks.py
@@ -35,7 +35,7 @@ class Hook:
         self.event_type = event
         self.handler = handler
         self.local = local
-        self.async = iscoroutinefunction(handler)
+        self.is_async = iscoroutinefunction(handler)
         self.wanted_components = get_type_hints(self.handler)
 
     def call_handler(self, components):


### PR DESCRIPTION
Fixes: #67 