### PR TITLE
[RFC] Add dependency-free auto reloader

### DIFF
--- a/vibora/reload.py
+++ b/vibora/reload.py
@@ -1,0 +1,141 @@
+# credits to werkzeug. this was ripped straight from the heart of _reloader.py
+import os
+import sys
+import time
+import subprocess
+import threading
+from itertools import chain
+
+from vibora.utils import cprint
+
+
+def _iter_module_files():
+    """This iterates over all relevant Python files.  It goes through all
+    loaded files from modules, all files in folders of already loaded modules
+    as well as all files reachable through a package.
+    """
+    # The list call is necessary on Python 3 in case the module
+    # dictionary modifies during iteration.
+    for module in list(sys.modules.values()):
+        if module is None:
+            continue
+        filename = getattr(module, '__file__', None)
+        if filename:
+            if os.path.isdir(filename) and \
+               os.path.exists(os.path.join(filename, "__init__.py")):
+                filename = os.path.join(filename, "__init__.py")
+
+            old = None
+            while not os.path.isfile(filename):
+                old = filename
+                filename = os.path.dirname(filename)
+                if filename == old:
+                    break
+            else:
+                if filename[-4:] in ('.pyc', '.pyo'):
+                    filename = filename[:-1]
+                yield filename
+
+
+def _get_args_for_reloading():
+    """Returns the executable. This contains a workaround for windows
+    if the executable is incorrectly reported to not have the .exe
+    extension which can cause bugs on reloading.
+    """
+    rv = [sys.executable]
+    py_script = sys.argv[0]
+    if os.name == 'nt' and not os.path.exists(py_script) and \
+       os.path.exists(py_script + '.exe'):
+        py_script += '.exe'
+    if os.path.splitext(rv[0])[1] == '.exe' and os.path.splitext(py_script)[1] == '.exe':
+        rv.pop(0)
+    rv.append(py_script)
+    rv.extend(sys.argv[1:])
+    return rv
+
+
+class ReloaderLoop(object):
+    # monkeypatched by testsuite. wrapping with `staticmethod` is required in
+    # case time.sleep has been replaced by a non-c function (e.g. by
+    # `eventlet.monkey_patch`) before we get here
+    _sleep = staticmethod(time.sleep)
+
+    def __init__(self, extra_files=None, interval=1):
+        self.extra_files = set(os.path.abspath(x)
+                               for x in extra_files or ())
+        self.interval = interval
+
+    def restart_with_reloader(self):
+        """Spawn a new Python interpreter with the same arguments as this one,
+        but running the reloader thread.
+        """
+        while 1:
+            args = _get_args_for_reloading()
+            new_environ = os.environ.copy()
+            new_environ['WERKZEUG_RUN_MAIN'] = 'true'
+
+            exit_code = subprocess.call(args, env=new_environ,
+                                        close_fds=False)
+            if exit_code != 3:
+                return exit_code
+
+    def trigger_reload(self, filename):
+        self.log_reload(filename)
+        sys.exit(3)
+
+    def log_reload(self, filename):
+        filename = os.path.abspath(filename)
+        cprint('Detected change in %r, reloading' % filename)
+
+    def run(self):
+        mtimes = {}
+        while 1:
+            for filename in chain(_iter_module_files(),
+                                  self.extra_files):
+                try:
+                    mtime = os.stat(filename).st_mtime
+                except OSError:
+                    continue
+
+                old_time = mtimes.get(filename)
+                if old_time is None:
+                    mtimes[filename] = mtime
+                    continue
+                elif mtime > old_time:
+                    self.trigger_reload(filename)
+            self._sleep(self.interval)
+
+
+def ensure_echo_on():
+    """Ensure that echo mode is enabled. Some tools such as PDB disable
+    it which causes usability issues after reload."""
+    # tcgetattr will fail if stdin isn't a tty
+    if not sys.stdin.isatty():
+        return
+    try:
+        import termios
+    except ImportError:
+        return
+    attributes = termios.tcgetattr(sys.stdin)
+    if not attributes[3] & termios.ECHO:
+        attributes[3] |= termios.ECHO
+        termios.tcsetattr(sys.stdin, termios.TCSANOW, attributes)
+
+
+def run_with_reloader(main_func, extra_files=None, interval=1,
+                      reloader_type='auto'):
+    """Run the given function in an independent python interpreter."""
+    import signal
+    reloader = ReloaderLoop(extra_files, interval)
+    signal.signal(signal.SIGTERM, lambda *args: sys.exit(0))
+    try:
+        if os.environ.get('WERKZEUG_RUN_MAIN') == 'true':
+            ensure_echo_on()
+            t = threading.Thread(target=main_func, args=())
+            t.setDaemon(True)
+            t.start()
+            reloader.run()
+        else:
+            sys.exit(reloader.restart_with_reloader())
+    except KeyboardInterrupt:
+        pass

--- a/vibora/server.py
+++ b/vibora/server.py
@@ -20,6 +20,7 @@ from .parsers.errors import BodyLimitError, HeadersLimitError
 from .utils import wait_server_available, get_free_port, cprint, pause
 from .hooks import Hook, Events
 from .application import Application
+from .reload import run_with_reloader
 
 
 class Vibora(Application):
@@ -289,3 +290,6 @@ class Vibora(Application):
                 self.running = False
             except KeyboardInterrupt:
                 self.clean_up()
+
+    def run_with_reloader(self, extra_files=None, interval=1, **kwargs):
+        run_with_reloader(lambda: self.run(**kwargs), extra_files, interval)


### PR DESCRIPTION
This PR introduces a `run_with_reloader` function on the `Vibora` class. This method will watch all loaded modules for file changes, and reload the server when there is a file change.

Below is an example:

```python
import time
from vibora import Vibora, Response


app = Vibora()


@app.route('/', cache=False)
async def home():
    return Response(str(time.time()).encode())


if __name__ == '__main__':
    # app.run(debug=False, port=8000)
    app.run_with_reloader(debug=False, port=8000)
```

`reload.py` copies from [Werkzeug reloader](https://github.com/pallets/werkzeug/blob/9cdcb93e3aa31f101bdf9477e54c48c40023b110/werkzeug/_reloader.py) to avoid adding external dependencies. It does not include watchdog, not support for python 2.

TODO:
- [ ] Add LICENSE from werkzeug
- [ ] Add tests
- [ ] Add documentation
- [ ] Update README

WDYT? Is this approach something that could work? If so, are there more considerations that need to be made?

I realize that in https://github.com/vibora-io/vibora/pull/61 @frnkvieira mentioned working on another implementation, but maybe this can save time for other features?