### PR TITLE
Change decorator args

### DIFF
--- a/vibora/blueprints.py
+++ b/vibora/blueprints.py
@@ -50,9 +50,7 @@ class Blueprint:
         return wrapper
 
     def route(self, pattern, methods=None, cache=None, name=None, hosts: list=None, limits: RouteLimits=None):
-        def register(*args):
-            handler = args[0]
-
+        def register(handler):
             # Checking if handler is co-routine.
             if not iscoroutinefunction(handler):
                 raise SyntaxError(f'Your route handler must be an async function. (Handler: {handler})')
@@ -83,9 +81,7 @@ class Blueprint:
         return register
 
     def websocket(self, pattern: str, name: str = None):
-        def register(*args):
-            handler = args[0]
-
+        def register(handler):
             # Get the function name in case the user doesn't provide one.
             # Route names are used to create URLs (I.e: links inside templates)
             route_name = handler.__name__ if name is None else name


### PR DESCRIPTION
```py
func(*args):
    handler = args[0]
```
does the same like
```py
func(handler):
    pass
```
but the last is more short.
Is there a reason why you choosed version 1?