### PR TITLE
Add missing b before pattern

### DIFF
--- a/samples/websockets.py
+++ b/samples/websockets.py
@@ -4,7 +4,7 @@ from vibora.websockets import WebsocketHandler
 app = Vibora()
 
 
-@app.websocket("/")
+@app.websocket(b"/")
 class ConnectedClient(WebsocketHandler):
     async def on_message(self, msg):
         print(msg)


### PR DESCRIPTION
Without `b` before the pattern it causes an error `Argument 'pattern' has incorrect type (expected bytes, got str)`