### PR TITLE
Fix document (issue 155): 'Vibora' object has no attribute 'add_compo…

### DIFF
--- a/docs/components/initial.md
+++ b/docs/components/initial.md
@@ -70,7 +70,7 @@ class Config:
 app = Vibora()
 
 # Registering the config instance.
-app.add_component(Config())
+app.components.add(Config())
 
 @app.route('/')
 async def home(request: Request, config: Config):


### PR DESCRIPTION
There is no `app.add_component` in `master` branch source code. Alternative method is `app.components.add()`. I changed the document accordingly