### PR TITLE
Fix broken imports in docs

### DIFF
--- a/docs/responses.md
+++ b/docs/responses.md
@@ -14,7 +14,8 @@ Bellow there are the most important ones:
 Automatically dumps Python objects and adds the correct headers to match the JSON format.
 
 ```py
-from vibora import Vibora, JsonResponse
+from vibora import Vibora
+from vibora.responses import JsonResponse
 
 app = Vibora()
 
@@ -50,7 +51,8 @@ The client will have 10 seconds to consume the 30 bytes, in case not, the connec
 
 ```py
 import asyncio
-from vibora import Vibora, StreamingResponse
+from vibora import Vibora
+from vibora.responses import StreamingResponse
 
 app = Vibora()
 

--- a/docs/schemas/initial.md
+++ b/docs/schemas/initial.md
@@ -51,7 +51,9 @@ class AddUserSchema(Schema):
 ###### Using your schema
 
 ```py
-from vibora import Request, Blueprint, JsonResponse
+from vibora import Request
+from vibora.blueprints import Blueprint
+from vibora.responses import JsonResponse
 from .schemas import AddUserSchema
 from .database import Database
 

--- a/docs/started.md
+++ b/docs/started.md
@@ -14,7 +14,8 @@ advantage of some new Python features.
 
 
 ```py
-from vibora import Vibora, JsonResponse
+from vibora import Vibora
+from vibora.responses import JsonResponse
 
 app = Vibora()
 


### PR DESCRIPTION
Docs from `docs/` use outdated imports. Therefore, some of them were raising `ImportError`, including the first example in `startted.md`