### PR TITLE
wait_server_available method ...

### DIFF
--- a/vibora/utils.py
+++ b/vibora/utils.py
@@ -131,9 +131,12 @@ def wait_server_available(host: str, port: int, timeout: int=10) -> None:
     :param port: TCP port used to connect.
     :return:
     """
-    sock = socket.socket()
-    sock.settimeout(timeout)
     while timeout > 0:
+        """ Start of change """
+        sock = socket.socket()
+        sock.settimeout(timeout)
+        """ End of change """
+        
         start_time = time.time()
         try:
             sock.connect((host, port))


### PR DESCRIPTION
Move the socket.socket() initialization to be inside the while loop. Having it outside initiates it only once and when closed inside the while loop, it starts to raise 'Bad File Descriptor' error since the socket is closed.

**Before submitting a pull request**, please make sure the following is done:

1. Fork the repository and create your branch from master.

2. Run the build.py and test.py scripts.

3. If you are fixing something, add tests that fail in the current version and pass in yours.

4. If you're developing a new feature open an issue first to discuss it. Some features may be useful to you but harmful to others be it because of performance, new dependencies or different perspectives.

5. One more time: Don't forget to add tests.

6. Ensure the entire test suite is passing and overall performance is not degraded.
