### PR TITLE
not using async def raise a SyntaxError

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -136,7 +136,7 @@ class YourCacheEngine(CacheEngine):
 
 
 @app.route('/', cache=YourCacheEngine(skip_hooks=True))
-def home():
+async def home():
     return Response(b'Hello World')
 ```
 


### PR DESCRIPTION
When discovering the framework and copy pasting from the documentation about routing

```
from vibora import Vibora, JsonResponse, Request, Response
app = Vibora()

from vibora.cache import CacheEngine
from time import sleep

class YourCacheEngine(CacheEngine):
    async def get(self, request: Request):
        return self.cache.get(request.url)

    async def store(self, request: Request, response):
        self.cache[request.url] = response

@app.route('/simplecache', cache=YourCacheEngine(skip_hooks=True))
def simple():  #bug is here
    sleep(5)
    return Response(b'simple')


if __name__ == '__main__':
    app.run(host="127.0.0.1", port=8000)
```
