### PR TITLE
fix route not match when visit with querystring

### DIFF
--- a/tests/router/strategies.py
+++ b/tests/router/strategies.py
@@ -1,5 +1,5 @@
 import uuid
-from vibora import Vibora, TestSuite
+from vibora import Vibora, TestSuite, Request
 from vibora.router import RouterStrategy
 from vibora.responses import Response
 
@@ -82,6 +82,14 @@ class StrictStrategyTestCase(TestSuite):
 
         client = self.app.test_client()
         self.assertEqual(405, (await client.request('/test/')).status_code)
+
+    async def test_route_with_query_string(self):
+        @self.app.route('/query/', methods=['GET'])
+        async def home(request: Request):
+            return Response(f'Name: {request.args["name"]}'.encode())
+        client = self.app.test_client()
+        self.assertEqual(200, (await client.request('/query/?name=vibora')).status_code)
+        self.assertEqual("Name: ['vibora']", (await client.request('/query/?name=test')).text)
 
     async def test_route_with_params_expect_found(self):
         @self.app.route('/<name>/')

--- a/tests/router/strategies.py
+++ b/tests/router/strategies.py
@@ -1,7 +1,7 @@
 import uuid
 from vibora import Vibora, TestSuite, Request
 from vibora.router import RouterStrategy
-from vibora.responses import Response
+from vibora.responses import Response, JsonResponse
 
 
 class RedirectStrategyTestCase(TestSuite):
@@ -84,12 +84,15 @@ class StrictStrategyTestCase(TestSuite):
         self.assertEqual(405, (await client.request('/test/')).status_code)
 
     async def test_route_with_query_string(self):
-        @self.app.route('/query/', methods=['GET'])
+        @self.app.route('/test')
         async def home(request: Request):
-            return Response(f'Name: {request.args["name"]}'.encode())
+            return JsonResponse({
+                'name': request.args['name']
+            })
+
         client = self.app.test_client()
-        self.assertEqual(200, (await client.request('/query/?name=vibora')).status_code)
-        self.assertEqual("Name: ['vibora']", (await client.request('/query/?name=test')).text)
+        self.assertEqual(200, (await client.request('/test', query={'name': 'vibora'})).status_code)
+        self.assertEqual({'name': ['vibora']}, (await client.request('/test', query={'name': 'vibora'})).json())
 
     async def test_route_with_params_expect_found(self):
         @self.app.route('/<name>/')

--- a/vibora/client/request.py
+++ b/vibora/client/request.py
@@ -23,7 +23,10 @@ class Request:
     async def encode(self, connection: Connection):
 
         # Headers
-        http_request = f'{self.method} {self.url.path} HTTP/1.1\r\n'
+        if self.url.query is None:
+            http_request = f'{self.method} {self.url.path} HTTP/1.1\r\n'
+        else:
+            http_request = f'{self.method} {self.url.path}?{self.url.query} HTTP/1.1\r\n'
         for header, value in self.headers.items():
             http_request += f'{header}: {str(value)}\r\n'
         if self.cookies:

--- a/vibora/request/request.pyx
+++ b/vibora/request/request.pyx
@@ -135,13 +135,21 @@ cdef class Request:
         return self._parsed_url
 
     @property
+    def path(self) -> str:
+        """
+
+        :return:
+        """
+        return self.parsed_url.path
+
+    @property
     def args(self) -> RequestParams:
         """
 
         :return:
         """
         if not self._args:
-            self._args = RequestParams(parse_qs(self.parsed_url.query))
+            self._args = RequestParams(parse_qs(self.parsed_url.query.decode()))
         return self._args
 
     @property

--- a/vibora/router/router.py
+++ b/vibora/router/router.py
@@ -219,8 +219,8 @@ class Router:
     def get_route(self, request: Request) -> 'Route':
         try:
             if not self.check_host:
-                return self._find_route(request.url, request.method)
-            return self._find_route_by_host(request.url, request.method, request.headers.get('host'))
+                return self._find_route(request.path, request.method)
+            return self._find_route_by_host(request.path, request.method, request.headers.get('host'))
         except MethodNotAllowed as error:
             request.context['allowed_methods'] = error.allowed_methods
             return self.default_handlers[405]


### PR DESCRIPTION
Resolves #227 

### Env
- Python 3.7.2
- vibora master branch

### Test Code

```Python
from vibora import Vibora, Response, Request
from vibora.router import RouterStrategy

app = Vibora()


@app.route('/')
async def home(request: Request):
    return Response(f'Name: {request.args["name"]}'.encode())


if __name__ == '__main__':
    app.run(host="0.0.0.0", port=8000)
```

When visit `http://localhost:8000/?name=Vibora`, will get 404 not found.

### Reason

vibora matchs route using `request.url`.

https://github.com/vibora-io/vibora/blob/4cda888f89aec6bfb2541ee53548ae1bf50fbf1b/vibora/router/router.py#L219-L228

But `request.url` is not a path, it will bring querystring, so it will not match.

Another problem is in `request.args`.

https://github.com/vibora-io/vibora/blob/4cda888f89aec6bfb2541ee53548ae1bf50fbf1b/vibora/request/request.pyx#L127-L145

From the definition, `url` is `bytes`. It will throw `KeyError` if you call `request.args["name"]` instead of `request.args[b"name"]`.

And current `test_client` will drop querystring, I fix it too.