### PR TITLE
fix server start documentation

### DIFF
--- a/docs/started.md
+++ b/docs/started.md
@@ -9,12 +9,11 @@ advantage of some new Python features.
 
 > In case you have trouble with Vibora dependencies: `pip install vibora` to install it without the extra libraries.
 
-
 2. Create a file called `anything.py` with the following code:
 
-
 ```py
-from vibora import Vibora, JsonResponse
+from vibora import Vibora
+from vibora.responses import JsonResponse
 
 app = Vibora()
 
@@ -29,9 +28,7 @@ if __name__ == '__main__':
 
 3. Run the server: `python3 anything.py`
 
-
-4. Open your browser at `http://127.0.0.1:8000`
-
+4) Open your browser at `http://127.0.0.1:8000`
 
 ### Creating a project
 


### PR DESCRIPTION
fix server start documentation.

Apparently `JsonResponse` is no longer inside Vibora(). And I was following the documentation but apparently it was not updated and I was getting this error: `File" index.py ", line 1, in <module>
    from vibora import Vibora, JsonResponse
ImportError: cannot import name 'JsonResponse'`